### PR TITLE
공통 컴포넌트 분리

### DIFF
--- a/components/common/InputBox.js
+++ b/components/common/InputBox.js
@@ -1,0 +1,37 @@
+import { StyleSheet, Text, TextInput, View } from "react-native";
+import React from "react";
+import { theme } from "../../colors";
+
+export const InputBox = ({ title, placeholder, value, onChangeText }) => {
+  return (
+    <View>
+      <Text>{title}</Text>
+      <View style={styles.inputContainer}>
+        <TextInput
+          style={styles.textInput}
+          placeholder={placeholder}
+          value={value}
+          onChangeText={onChangeText}
+        />
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  inputContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    borderColor: theme.main,
+    borderWidth: 2,
+    marginVertical: 10,
+    padding: 5,
+  },
+  textInput: {
+    padding: 10,
+    flex: 1,
+  },
+});
+
+export default InputBox;

--- a/components/common/InputBox.js
+++ b/components/common/InputBox.js
@@ -1,8 +1,22 @@
 import { StyleSheet, Text, TextInput, View } from "react-native";
 import React from "react";
 import { theme } from "../../colors";
+import { MaterialCommunityIcons } from "@expo/vector-icons";
 
-export const InputBox = ({ title, placeholder, value, onChangeText }) => {
+export const InputBox = ({
+  title,
+  placeholder,
+  value,
+  onChangeText,
+  secureTextEntry,
+  isPassword,
+  isPasswordVisible,
+  setPasswordVisible,
+}) => {
+  const toggleShowPassword = () => {
+    setPasswordVisible(!isPasswordVisible);
+  };
+
   return (
     <View>
       <Text>{title}</Text>
@@ -12,7 +26,15 @@ export const InputBox = ({ title, placeholder, value, onChangeText }) => {
           placeholder={placeholder}
           value={value}
           onChangeText={onChangeText}
+          secureTextEntry={secureTextEntry}
         />
+        {isPassword ? (
+          <MaterialCommunityIcons
+            name={isPasswordVisible ? "eye-off" : "eye"}
+            style={styles.showPasswordIcon}
+            onPress={toggleShowPassword}
+          />
+        ) : null}
       </View>
     </View>
   );
@@ -31,6 +53,11 @@ const styles = StyleSheet.create({
   textInput: {
     padding: 10,
     flex: 1,
+  },
+  showPasswordIcon: {
+    paddingHorizontal: 10,
+    color: "#aaa",
+    fontSize: 24,
   },
 });
 

--- a/components/common/ProfileImage.js
+++ b/components/common/ProfileImage.js
@@ -1,0 +1,50 @@
+import { Image, Pressable, StyleSheet, View } from "react-native";
+import React from "react";
+import * as ImagePicker from "expo-image-picker";
+
+const ProfileImage = ({ setImageUrl, profilePicture }) => {
+  const [libraryPermission, requestLibraryPermission] =
+    ImagePicker.useMediaLibraryPermissions();
+
+  const uploadImage = async () => {
+    if (!libraryPermission?.granted) {
+      const permission = await requestLibraryPermission();
+      if (!permission.granted) {
+        return null;
+      }
+    }
+
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      allowsEditing: true,
+      quality: 1,
+      aspect: [1, 1],
+    });
+
+    if (!result.canceled) {
+      setImageUrl(result.assets[0].uri);
+    }
+  };
+
+  return (
+    <View style={styles.profilePictureContainer}>
+      <Pressable onPress={uploadImage}>
+        <Image source={profilePicture} style={styles.profilePicture} />
+      </Pressable>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  profilePictureContainer: {
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  profilePicture: {
+    borderRadius: 50,
+    width: 100,
+    height: 100,
+  },
+});
+
+export default ProfileImage;

--- a/components/common/SubmitButton.js
+++ b/components/common/SubmitButton.js
@@ -1,0 +1,35 @@
+import { View, StyleSheet, Pressable, Text } from "react-native";
+import { theme } from "../../colors";
+import React from "react";
+
+export const SubmitButton = ({ buttonText, onPress, style }) => {
+  return (
+    <View style={styles.buttonContainer}>
+      <Pressable
+        style={[styles.submitButton, style]}
+        onPress={onPress}
+      >
+        <Text style={styles.buttonText}>{buttonText}</Text>
+      </Pressable>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  buttonContainer: {
+    marginVertical: 35,
+  },
+  submitButton: {
+    backgroundColor: theme.main,
+    padding: 20,
+    borderRadius: 10,
+    alignItems: "center",
+  },
+  buttonText: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: theme.white,
+  },
+});
+
+export default SubmitButton;

--- a/components/common/Title.js
+++ b/components/common/Title.js
@@ -1,0 +1,17 @@
+import { StyleSheet, Text } from "react-native";
+import React from "react";
+import { theme } from "../../colors";
+
+const Title = ({ title }) => {
+  return <Text style={styles.sectionText}>{title}</Text>;
+};
+
+const styles = StyleSheet.create({
+  sectionText: {
+    color: theme.main,
+    fontSize: 44,
+    marginVertical: 20,
+  },
+});
+
+export default Title;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "expo-image-picker": "~14.3.2",
         "expo-status-bar": "~1.11.1",
         "react": "18.2.0",
+        "react-hook-form": "^7.51.1",
         "react-native": "0.73.4",
         "react-native-paper": "^5.12.3"
       },
@@ -13426,6 +13427,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.51.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.51.1.tgz",
+      "integrity": "sha512-ifnBjl+kW0ksINHd+8C/Gp6a4eZOdWyvRv0UBaByShwU8JbVx5hTcTWEcd5VdybvmPTATkVVXk9npXArHmo56w==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "expo-image-picker": "~14.3.2",
     "expo-status-bar": "~1.11.1",
     "react": "18.2.0",
+    "react-hook-form": "^7.51.1",
     "react-native": "0.73.4",
     "react-native-paper": "^5.12.3"
   },

--- a/pages/ProfileUpdate.js
+++ b/pages/ProfileUpdate.js
@@ -14,6 +14,7 @@ import { theme } from "../colors";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import * as ImagePicker from "expo-image-picker";
 import React, { useState } from "react";
+import SubmitButton from "../components/common/SubmitButton";
 
 const PASSWORD_INDEX = [
   "current password",
@@ -158,16 +159,12 @@ export default function ProfileUpdate() {
         </View>
       </View>
 
-      <View style={styles.buttonContainer}>
-        <TouchableOpacity
-          style={styles.submitButton}
-          onPress={() => {
-            alert(`nickname: ${nickname}, password: ${newPassword} 변경 시도.`);
-          }}
-        >
-          <Text style={styles.btnText}>변경</Text>
-        </TouchableOpacity>
-      </View>
+      <SubmitButton
+        buttonText="변경"
+        onPress={() => {
+          alert(`nickname: ${nickname}, password: ${newPassword} 변경 시도.`);
+        }}
+      />
     </KeyboardAvoidingView>
   );
 }
@@ -215,19 +212,5 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
     color: "#aaa",
     fontSize: 24,
-  },
-  buttonContainer: {
-    marginVertical: 35,
-  },
-  submitButton: {
-    backgroundColor: theme.main,
-    padding: 20,
-    borderRadius: 10,
-    alignItems: "center",
-  },
-  btnText: {
-    fontSize: 16,
-    fontWeight: "600",
-    color: theme.white,
   },
 });

--- a/pages/ProfileUpdate.js
+++ b/pages/ProfileUpdate.js
@@ -4,17 +4,16 @@ import {
   View,
   KeyboardAvoidingView,
   Platform,
-  Text,
   Pressable,
   Image,
   TouchableOpacity,
 } from "react-native";
-import { theme } from "../colors";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import * as ImagePicker from "expo-image-picker";
 import React, { useState } from "react";
 import SubmitButton from "../components/common/SubmitButton";
 import InputBox from "../components/common/InputBox";
+import Title from "../components/common/Title";
 
 export default function ProfileUpdate() {
   const [imageUrl, setImageUrl] = useState(null);
@@ -73,7 +72,7 @@ export default function ProfileUpdate() {
       </View>
 
       <View style={styles.mainContainer}>
-        <Text style={styles.sectionText}>개인 정보 변경</Text>
+        <Title title="개인 정보 변경" />
 
         <View style={styles.profilePictureContainer}>
           <Pressable onPress={uploadImage}>
@@ -141,11 +140,6 @@ const styles = StyleSheet.create({
   },
   mainContainer: {
     flex: 1,
-  },
-  sectionText: {
-    color: theme.main,
-    fontSize: 44,
-    marginVertical: 20,
   },
   profilePictureContainer: {
     alignItems: "center",

--- a/pages/ProfileUpdate.js
+++ b/pages/ProfileUpdate.js
@@ -8,7 +8,6 @@ import {
   Pressable,
   Image,
   TouchableOpacity,
-  TextInput,
 } from "react-native";
 import { theme } from "../colors";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
@@ -16,12 +15,6 @@ import * as ImagePicker from "expo-image-picker";
 import React, { useState } from "react";
 import SubmitButton from "../components/common/SubmitButton";
 import InputBox from "../components/common/InputBox";
-
-const PASSWORD_INDEX = [
-  "current password",
-  "new password",
-  "new password check",
-];
 
 export default function ProfileUpdate() {
   const [imageUrl, setImageUrl] = useState(null);
@@ -35,16 +28,6 @@ export default function ProfileUpdate() {
   const [isNewPasswordVisible, setNewPasswordVisible] = useState(false);
   const [checkNewPassword, setCheckNewPassword] = useState("");
   const [isCheckNewPasswordVisible, setCheckNewPasswordVisible] = useState(false);
-
-  const toggleShowPassword = (index) => {
-    if (index === PASSWORD_INDEX[0]) {
-      setCurrentPasswordVisible(!isCurrentPasswordVisible);
-    } else if (index === PASSWORD_INDEX[1]) {
-      setNewPasswordVisible(!isNewPasswordVisible);
-    } else if (index === PASSWORD_INDEX[2]) {
-      setCheckNewPasswordVisible(!isCheckNewPasswordVisible);
-    }
-  };
 
   const uploadImage = async () => {
     if (!libraryPermission?.granted) {
@@ -103,55 +86,38 @@ export default function ProfileUpdate() {
           placeholder="기존 닉네임"
           value={nickname}
           onChangeText={setNickname}
+          isPassword={false}
         />
-
-        <Text>현재 비밀번호</Text>
-        <View style={styles.inputContainer}>
-          <TextInput
-            style={styles.textInput}
-            placeholder="현재 비밀번호를 입력하세요."
-            value={currentPassword}
-            onChangeText={setCurrentPassword}
-            secureTextEntry={!isCurrentPasswordVisible}
-          />
-          <MaterialCommunityIcons
-            name={isCurrentPasswordVisible ? "eye-off" : "eye"}
-            style={styles.showPasswordIcon}
-            onPress={() => toggleShowPassword(PASSWORD_INDEX[0])}
-          />
-        </View>
-
-        <Text>새 비밀번호</Text>
-        <View style={styles.inputContainer}>
-          <TextInput
-            style={styles.textInput}
-            placeholder="변경할 비밀번호를 입력하세요."
-            value={newPassword}
-            onChangeText={setNewPassword}
-            secureTextEntry={!isNewPasswordVisible}
-          />
-          <MaterialCommunityIcons
-            name={isNewPasswordVisible ? "eye-off" : "eye"}
-            style={styles.showPasswordIcon}
-            onPress={() => toggleShowPassword(PASSWORD_INDEX[1])}
-          />
-        </View>
-
-        <Text>새 비밀번호 확인</Text>
-        <View style={styles.inputContainer}>
-          <TextInput
-            style={styles.textInput}
-            placeholder="변경할 비밀번호를 다시 입력하세요."
-            value={checkNewPassword}
-            onChangeText={setCheckNewPassword}
-            secureTextEntry={!isCheckNewPasswordVisible}
-          />
-          <MaterialCommunityIcons
-            name={isCheckNewPasswordVisible ? "eye-off" : "eye"}
-            style={styles.showPasswordIcon}
-            onPress={() => toggleShowPassword(PASSWORD_INDEX[2])}
-          />
-        </View>
+        <InputBox
+          title="현재 비밀번호"
+          placeholder="현재 비밀번호를 입력하세요."
+          value={currentPassword}
+          onChangeText={setCurrentPassword}
+          secureTextEntry={!isCurrentPasswordVisible}
+          isPassword={true}
+          isPasswordVisible={isCurrentPasswordVisible}
+          setPasswordVisible={setCurrentPasswordVisible}
+        />
+        <InputBox
+          title="새 비밀번호"
+          placeholder="변경할 비밀번호를 입력하세요."
+          value={newPassword}
+          onChangeText={setNewPassword}
+          secureTextEntry={!isNewPasswordVisible}
+          isPassword={true}
+          isPasswordVisible={isNewPasswordVisible}
+          setPasswordVisible={setNewPasswordVisible}
+        />
+        <InputBox
+          title="새 비밀번호 확인"
+          placeholder="변경할 비밀번호를 다시 입력하세요."
+          value={checkNewPassword}
+          onChangeText={setCheckNewPassword}
+          secureTextEntry={!isCheckNewPasswordVisible}
+          isPassword={true}
+          isPasswordVisible={isCheckNewPasswordVisible}
+          setPasswordVisible={setCheckNewPasswordVisible}
+        />
       </View>
 
       <SubmitButton
@@ -181,19 +147,6 @@ const styles = StyleSheet.create({
     fontSize: 44,
     marginVertical: 20,
   },
-  inputContainer: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    borderColor: theme.main,
-    borderWidth: 2,
-    marginVertical: 10,
-    padding: 5,
-  },
-  textInput: {
-    padding: 10,
-    flex: 1,
-  },
   profilePictureContainer: {
     alignItems: "center",
     justifyContent: "center",
@@ -202,10 +155,5 @@ const styles = StyleSheet.create({
     borderRadius: 50,
     width: 100,
     height: 100,
-  },
-  showPasswordIcon: {
-    paddingHorizontal: 10,
-    color: "#aaa",
-    fontSize: 24,
   },
 });

--- a/pages/ProfileUpdate.js
+++ b/pages/ProfileUpdate.js
@@ -4,20 +4,17 @@ import {
   View,
   KeyboardAvoidingView,
   Platform,
-  Pressable,
-  Image,
   TouchableOpacity,
 } from "react-native";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
-import * as ImagePicker from "expo-image-picker";
 import React, { useState } from "react";
 import SubmitButton from "../components/common/SubmitButton";
 import InputBox from "../components/common/InputBox";
 import Title from "../components/common/Title";
+import ProfileImage from "../components/common/ProfileImage";
 
 export default function ProfileUpdate() {
   const [imageUrl, setImageUrl] = useState(null);
-  const [libraryPermission, requestLibraryPermission] = ImagePicker.useMediaLibraryPermissions();
   const profilePicture = imageUrl === null ? require("../assets/favicon.png") : { uri: imageUrl };
 
   const [nickname, setNickname] = useState("기존 닉네임");
@@ -27,27 +24,6 @@ export default function ProfileUpdate() {
   const [isNewPasswordVisible, setNewPasswordVisible] = useState(false);
   const [checkNewPassword, setCheckNewPassword] = useState("");
   const [isCheckNewPasswordVisible, setCheckNewPasswordVisible] = useState(false);
-
-  const uploadImage = async () => {
-    if (!libraryPermission?.granted) {
-      const permission = await requestLibraryPermission();
-      if (!permission.granted) {
-        return null;
-      }
-    }
-
-    // upload image
-    const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.Images,
-      allowsEditing: true,
-      quality: 1,
-      aspect: [1, 1],
-    });
-
-    if (!result.canceled) {
-      setImageUrl(result.assets[0].uri);
-    }
-  };
 
   return (
     <KeyboardAvoidingView
@@ -74,11 +50,10 @@ export default function ProfileUpdate() {
       <View style={styles.mainContainer}>
         <Title title="개인 정보 변경" />
 
-        <View style={styles.profilePictureContainer}>
-          <Pressable onPress={uploadImage}>
-            <Image source={profilePicture} style={styles.profilePicture} />
-          </Pressable>
-        </View>
+        <ProfileImage
+          setImageUrl={setImageUrl}
+          profilePicture={profilePicture}
+        />
 
         <InputBox
           title="닉네임"
@@ -140,14 +115,5 @@ const styles = StyleSheet.create({
   },
   mainContainer: {
     flex: 1,
-  },
-  profilePictureContainer: {
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  profilePicture: {
-    borderRadius: 50,
-    width: 100,
-    height: 100,
   },
 });

--- a/pages/ProfileUpdate.js
+++ b/pages/ProfileUpdate.js
@@ -15,6 +15,7 @@ import { MaterialCommunityIcons } from "@expo/vector-icons";
 import * as ImagePicker from "expo-image-picker";
 import React, { useState } from "react";
 import SubmitButton from "../components/common/SubmitButton";
+import InputBox from "../components/common/InputBox";
 
 const PASSWORD_INDEX = [
   "current password",
@@ -24,10 +25,8 @@ const PASSWORD_INDEX = [
 
 export default function ProfileUpdate() {
   const [imageUrl, setImageUrl] = useState(null);
-  const [libraryPermission, requestLibraryPermission] =
-    ImagePicker.useMediaLibraryPermissions();
-  const profilePicture =
-    imageUrl === null ? require("../assets/favicon.png") : { uri: imageUrl };
+  const [libraryPermission, requestLibraryPermission] = ImagePicker.useMediaLibraryPermissions();
+  const profilePicture = imageUrl === null ? require("../assets/favicon.png") : { uri: imageUrl };
 
   const [nickname, setNickname] = useState("기존 닉네임");
   const [currentPassword, setCurrentPassword] = useState("");
@@ -35,8 +34,7 @@ export default function ProfileUpdate() {
   const [newPassword, setNewPassword] = useState("");
   const [isNewPasswordVisible, setNewPasswordVisible] = useState(false);
   const [checkNewPassword, setCheckNewPassword] = useState("");
-  const [isCheckNewPasswordVisible, setCheckNewPasswordVisible] =
-    useState(false);
+  const [isCheckNewPasswordVisible, setCheckNewPasswordVisible] = useState(false);
 
   const toggleShowPassword = (index) => {
     if (index === PASSWORD_INDEX[0]) {
@@ -100,15 +98,12 @@ export default function ProfileUpdate() {
           </Pressable>
         </View>
 
-        <Text>닉네임</Text>
-        <View style={styles.inputContainer}>
-          <TextInput
-            style={styles.textInput}
-            placeholder="기존 닉네임"
-            value={nickname}
-            onChangeText={setNickname}
-          />
-        </View>
+        <InputBox
+          title="닉네임"
+          placeholder="기존 닉네임"
+          value={nickname}
+          onChangeText={setNickname}
+        />
 
         <Text>현재 비밀번호</Text>
         <View style={styles.inputContainer}>


### PR DESCRIPTION
#7 , #15 구현했습니다.

/components/common 아래에 다른 페이지에서도 사용되는 컴포넌트 분리하였고
/pages/ProfileUpdate.js에서 custom component 적용하며 메인 틀 수정했습니다.

### 구현 완료
- [x] InputBox - text, password 박스를 한 파일에서 구현
- [x] 헤더 - 뒤로가기는 네비게이션에 포함될 것 같아 제목 부분만 뺐어요
- [x] 사진 업로드 - 앨범에서 사진 선택 후 변경 로직
- [x] 제출 버튼

react-hook-form은 아직 적용 못 했습니다..
더 좋은 의견 있으면 마음껏 리뷰 달아주세요~